### PR TITLE
Add semi: true to .prettierrc

### DIFF
--- a/configs/.prettierrc
+++ b/configs/.prettierrc
@@ -1,6 +1,6 @@
 {
   "arrowParens": "avoid",
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",


### PR DESCRIPTION
I'd suggest enabling semicolons (ASI) as the default - to me it feels like the more common way to do it.