### PR TITLE
add github as known host

### DIFF
--- a/setup-git
+++ b/setup-git
@@ -9,5 +9,6 @@ ssh-keygen -t ed25519 -C $email;
 eval "$(ssh-agent -s)";
 echo "Host *\n    AddKeysToAgent yes\n    UseKeychain yes\n    IdentityFile ~/.ssh/id_ed25519" > ~/.ssh/config;
 ssh-add -K ~/.ssh/id_ed25519;
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts # add github.com to the list of known hosts
 echo "------------------------\n\nPlease follow the instructions:\n-------------------\n" &&
 gh auth login;


### PR DESCRIPTION
I got "Host Key Verification Failed" after running this setup when trying to interact with github.com.

If I remember correctly in the past i was just asked in the command line if I wanted to add this host to the list of known hosts, but this does not seem to be the case anymore.

This PR adds github as a known host automatically.