### PR TITLE
use fnm to install node lts

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -52,3 +52,6 @@ setopt extendedglob
 
 # Enable fuzzy backwards search
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# Setup fnm (fast node manager)
+eval "$(fnm env --use-on-cd)"

--- a/install-brew
+++ b/install-brew
@@ -9,7 +9,15 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/`echo $USER`/.zprofil
 eval "$(/opt/homebrew/bin/brew shellenv)";
 fi
 
-for x in go gh zsh git antigen zsh-completions exa fasd tree bat httpie lynx node; do brew install $x; done;
+for x in go gh zsh git antigen zsh-completions exa fasd tree bat httpie lynx fnm; do brew install $x; done;
 brew install fzf && $(brew --prefix)/opt/fzf/install &&
 echo "------------------------\n\nInstalled formulae:\n-------------------\n" &&
 brew list --formulae -1
+
+echo "Setting up Node LTS\n";
+eval "$(fnm env --use-on-cd)";
+fnm install lts-latest;
+fnm alias lts-latest default;
+fnm use default;
+echo "Installed Node Version:";
+node -v;


### PR DESCRIPTION
This PR removes node from brew install and instead introduces [fnm](https://github.com/Schniz/fnm) which is a more modern variant of nvm which I personally dislike.

fnm now always installs the latest LTS version of node.