### PR TITLE
add new (second) git setup

### DIFF
--- a/setup-git-and-ssh
+++ b/setup-git-and-ssh
@@ -1,0 +1,14 @@
+#!/usr/bin/env zsh
+vared -p 'Enter your full name (e.g. John Doe): ' -c fullname &&
+git config --global user.name $fullname &&
+vared -p 'Enter your e-mail (john@johndoe.com): ' -c email &&
+git config --global user.email $email;
+git config --global pull.ff "only";
+git config --global init.defaultBranch main
+ssh-keygen -t ed25519 -C $email;
+eval "$(ssh-agent -s)";
+echo "Host *\n    AddKeysToAgent yes\n    UseKeychain yes\n    IdentityFile ~/.ssh/id_ed25519" > ~/.ssh/config;
+ssh-add -K ~/.ssh/id_ed25519;
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts # add github.com to the list of known hosts
+echo "------------------------\n\nPlease follow the instructions:\n-------------------\n" &&
+gh auth login;

--- a/setup-git-and-ssh
+++ b/setup-git-and-ssh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 vared -p 'Enter your full name (e.g. John Doe): ' -c fullname &&
 git config --global user.name $fullname &&
-vared -p 'Enter your e-mail (john@johndoe.com): ' -c email &&
+vared -p 'Enter the e-mail you use for GitHub (john@johndoe.com): ' -c email &&
 git config --global user.email $email;
 git config --global pull.ff "only";
 git config --global init.defaultBranch main


### PR DESCRIPTION
For the new curriculum/format  we need a slightly changed git and ssh setup script. We removed: `git config --global core.pager bat; # is installed via brew install bat` and made a minor text change.

Therefore I added a new file without this step.